### PR TITLE
Adding async sample for reading from a lakehouse

### DIFF
--- a/PYTHON/Lakehouse/read_csv_from_lakehouse_async.py
+++ b/PYTHON/Lakehouse/read_csv_from_lakehouse_async.py
@@ -1,0 +1,36 @@
+
+# This sample reads a CSV file from a lakehouse using pandas. Function takes file name as an input parameter
+# Complete these steps before testing this funtion 
+#   1. Select Manage connections to connect to Lakehouse. 
+#   2. Select Library Management and add pandas library 
+
+import pandas as pd 
+
+# Replace the alias "<My Lakehouse alias>" with your connection alias.
+@udf.connection(argName="myLakehouse", alias="<My Lakehouse alias>")
+@udf.function()
+async def read_csv_from_lakehouse(myLakehouse: fn.FabricLakehouseClient, csvFileName: str) -> str:
+
+    # Connect to the Lakehouse
+    connection = myLakehouse.connectToFilesAsync()   
+
+    # Download the CSV file from the Lakehouse
+    csvFile = connection.get_file_client(csvFileName)
+
+    downloadFile = await csvFile.download_file()
+    csvData = await downloadFile.readall()
+    
+    # Read the CSV data into a pandas DataFrame
+    from io import StringIO
+    df = pd.read_csv(StringIO(csvData.decode('utf-8')))
+
+    # Display the DataFrame    
+    result="" 
+    for index, row in df.iterrows():
+        result=result + "["+ (",".join([str(item) for item in row]))+"]"
+    
+    # Close the connection
+    csvFile.close()
+    connection.close()
+
+    return f"CSV file read successfully.{result}"

--- a/PYTHON/index.json
+++ b/PYTHON/index.json
@@ -42,6 +42,12 @@
             "data":"Lakehouse/read_csv_file_from_lakehouse.py"
          },
          {
+            "name":"Read csv file from lakehouse (Async)",
+            "description":"This sample reads a CSV file from a lakehouse using pandas. Function takes file name as an input parameter. This is an async version of the function.",
+            "dateAdded":"2025-06-12T00:00:00Z",
+            "data":"Lakehouse/read_csv_file_from_lakehouse_async.py"
+         },
+         {
             "name":"Query data from lakehouse tables",
             "description":"This sample reads data from a table in a lakehouse.",
             "dateAdded":"2024-11-05T00:00:00Z",


### PR DESCRIPTION
This PR provides a sample which showcases how you can use the async/await keywords in querying lakehouses in Faric UDF.

Example run:
![image](https://github.com/user-attachments/assets/6fa9956f-7737-4781-8987-a38e79faff4f)
