### PR TITLE
Update copilot instructions in the Python UDF template. 

### DIFF
--- a/Templates/Python/UDF/HelloFabric/.github/copilot-instructions.md
+++ b/Templates/Python/UDF/HelloFabric/.github/copilot-instructions.md
@@ -1,53 +1,50 @@
-# Copilot Instructions for Fabric User Data Functions
+## Copilot Instructions — Fabric UDF
 
-## Project Overview
-This is a Microsoft Fabric User Data Functions (UDF) project written in Python. UDFs are serverless functions that process data within Fabric environments.
+Primary objective: Generate correct Microsoft Fabric User Data Functions (UDFs) in Python with strict grounding, zero fabrication, and minimal verbosity.
 
-## Key Information for Code Generation
+### Constitutional Rules (Always)
+- Conceptual grounding: All conceptual / architectural / policy / security / performance answers MUST be grounded ONLY in Microsoft Docs via the Microsoft Docs MCP server. If that server (`microsoft.docs.mcp`) is not available, respond with EXACTLY (no extra words): "Microsoft Docs MCP server not available. Install/enable it: https://learn.microsoft.com/en-us/training/support/mcp-get-started#configure-vs-code"
+- Sample grounding: For any code generation or modification, first fetch `samples-llms.txt` from the official GitHub samples index (#fetch https://raw.githubusercontent.com/microsoft/fabric-user-data-functions-samples/refs/heads/main/PYTHON/samples-llms.txt) and then fetch at least one concrete Python sample it links to. Implement strictly by adapting the closest single sample. If no sample is available, state that explicitly and do not invent APIs.
+- UDF essentials: Follow the mandatory UDF practices below (single-file layout, parameter casing, connections/placeholders, warnings, validation, and response schema).
 
-### Project Structure
-- **All code goes in `function_app.py`** - single file for all functions
-- `definition.json` - contains configured libraries and connections
-- **Never modify `definition.json`** - it's managed by the Fabric portal
+### Scope & Layout
+- "Function" means a Fabric UDF entry point in this repo.
+- Single-file code: Place all executable UDF code in `function_app.py`. Only add small helpers in the same file unless a separate module is clearly necessary.
+- No alternate hosting/execution models unless the user explicitly requests a pivot away from Fabric UDFs.
 
-### Dependencies Management
-- **⚠️ CRITICAL**: Always check `definition.json` for configured libraries before using imports
-- **You can add libraries to `requirements.txt`** but **warn in bold** that user must configure them in Fabric portal
-- **Warn in bold** when suggesting libraries not in `definition.json`
-- Libraries added locally won't work in production until configured in Fabric portal
-- Custom packages go in `privateLibraries/` as wheel files
+### Sample-First Workflow (Code Tasks)
+1) Fetch index: Retrieve `samples-llms.txt` from GitHub and parse it.
+2) Fetch sample: Follow a #fetch link to a concrete Python sample that best matches the needed binding/decorator pattern. Selection order:
+   - Same trigger/binding decorators; else closest semantics; else smallest working example.
+3) Adapt patterns: Reuse the sample’s binding signatures, decorators, parameter naming style, logging, response envelope, and error handling. Do not combine multiple unique sample patterns unless necessary.
+4) Cite: Name the sample file used (file path only). Avoid large quotations.
+5) If a matching sample cannot be fetched: say so explicitly and implement the safest minimal, clearly marked "Unverified — needs doc lookup".
 
-### Connections
-- **⚠️ CRITICAL**: Check `definition.json` "connectedDataSources" before using connections
-- **You can suggest connection code** but **warn in bold** that user must configure connections in Fabric portal if not in `definition.json`
-- **Connections won't work in production** until configured in Fabric portal
-- Connections must be added via Fabric portal
+### Concept Questions (Docs Tasks)
+- Source: Microsoft Docs through active MCP only; paraphrase concisely.
+- If MCP missing: return only the directive line above—no additions.
 
-### Function Development Best Practices
-- Use descriptive snake_case names for functions
-- **Use camelCase for parameter names** (never snake_case for parameters)
-- **Don't use default values in function signatures** - handle defaults inside function logic instead
-- **Always include inline Python docstrings** to describe what functions do
-- Include proper error handling and logging
-- Test locally with F5 debugging before deployment
+### UDF Essentials
+- Naming: function names snake_case; parameters camelCase.
+- Parameter enforcement:
+  - Public UDF parameters MUST be lowerCamelCase. Convert snake_case inputs to camelCase (`user_id` → `userId`) and proceed; add a short inline comment mapping if relevant.
+  - Do not leave underscores in parameter names. If conflict occurs after conversion, append a numeric suffix (e.g., `userId2`).
+  - Signature defaults: PROHIBITED. No '=' in the parameter list (covers `None`, union/optional, numeric/string literals, splat defaults). All params are required.
+- Validation: At start, validate required parameters for None/empty/type; return the sample’s standard error envelope or raise ValueError per sample pattern.
+ - Logging: Use standard library logging directly (`import logging` then calls like `logging.info(...)`); Use info for start/end and key branches, warning for recoverable anomalies, error for failures; never silently swallow exceptions.
+- Response schema: Mirror the sample’s schema exactly (commonly `status`/`result`/`error`). Add fields only if explicitly requested.
 
-### Available VS Code Tasks
-- `func: host start` - Start function host (only do this if asked)
-- `pip install (functions)` - Install dependencies
+### Dependencies, Connections, Warnings
+- Prefer stdlib. Add external libraries only with explicit user need or clear benefit (perf/correctness/security). Place custom wheels in `privateLibraries/` if used.
+- Connections: Verify configured alias names. If unknown, insert a clear placeholder such as `PLACEHOLDER_DATA_LAKE_CONN  # TODO: replace with configured connection alias` and proceed.
+- `definition.json` (if present) outranks assumptions; align imports/bindings to it.
+- Warning policy: Emit a single bold warning only when introducing a new external library or adding an unverified connection alias (or changing prior connection assumptions). Do not repeat the same warning in later turns unless a new item appears.
 
-### When Generating Code
-1. **Always check dependencies** against `definition.json`
-2. **Always check connections** against `definition.json`
-3. **Include type hints** for all functions
-4. **Add logging** for debugging
-5. **Include reasonable error handling**
-6. **Warn boldly** about unconfigured libraries/connections
+### Guardrails
+- Do not invent APIs or bindings not seen in samples or docs.
+- Keep edits minimal and focused on the request; avoid unrelated refactors.
+- If uncertainty remains after samples/docs, choose the safest minimal approach and label it Unverified.
 
-### Reference Files
-- **Code samples and patterns**: Always try to fetch examples from the [samples-llms.txt](https://raw.githubusercontent.com/microsoft/fabric-user-data-functions-samples/refs/heads/main/PYTHON/samples-llms.txt) file
-- **SDK documentation**: Only if samples are insufficient, try to query the `microsoft.docs.mcp` server for all Microsoft Fabric User Data Functions SDK documentation and guidance
-
-## Querying Microsoft Documentation
-Use the `microsoft.docs.mcp` server to search Microsoft's official documentation for SDK details, API references, and implementation guidance. This provides access to the latest Microsoft Fabric documentation that may be more current than training data.
-**If the MCP server is unavailable**: Direct users to install it from https://github.com/MicrosoftDocs/mcp
-**Tool Usage**: Only reference MCP tools when actively needed for documentation queries - don't mention them proactively.
+### Output Discipline
+- Be concise. Summarize what changed and why in a few bullets.
+- Reference the explicit sample by filename/path. Avoid long code pastes from samples; adapt the pattern instead.


### PR DESCRIPTION
We were not seeeing good results with fetching samples or grounding in docs and actual samples. I did some meta prompting to re-write it and remove the inncorrect dependencies (like definition.json) improved it significantly. It's been tested with Sonnet 4 and GPT 5.  Seems to work well much better than before.