### PR TITLE
test(kusto): assert no json.loads/json.dumps on the streaming 200 path

### DIFF
--- a/Templates/Python/ConnectorFunction/HelloFabric/test_function_app.py
+++ b/Templates/Python/ConnectorFunction/HelloFabric/test_function_app.py
@@ -9,7 +9,9 @@ chunks. The tests assert that the 200 path:
   * relays MORE THAN ONE chunk for a multi-chunk result (true streaming),
   * never buffers or parses the body (`resp.text()` is never called), and
   * forwards the SDK-supplied clientRequestId as the `x-ms-client-request-id`
-    request header.
+    request header, and
+  * never calls `json.loads` / `json.dumps` (asserted with a stdlib tripwire,
+    not merely inferred from the absence of a buffering call).
 
 Run directly (`python3 test_function_app.py`) or under pytest. Only requires
 aiohttp to be importable (function_app imports it at module load).
@@ -199,6 +201,42 @@ async def _check_execute_command_routes_to_mgmt_and_streams():
     ), "clientRequestId is forwarded for executeCommand too"
 
 
+async def _check_no_json_parsing_on_200_path():
+    # Yadi's step-6 ask, asserted directly rather than inferred: the 200 path
+    # must never parse or re-serialize the body. A tripwire replaces the stdlib
+    # `json.loads` / `json.dumps` for the duration of the relay and records any
+    # call, so an accidental reintroduction of the buffer-and-rebuild pattern
+    # fails here instead of silently costing ~4x peak memory.
+    import json as _json
+
+    calls = []
+    real_loads, real_dumps = _json.loads, _json.dumps
+
+    def _trip_loads(*args, **kwargs):
+        calls.append("json.loads")
+        return real_loads(*args, **kwargs)
+
+    def _trip_dumps(*args, **kwargs):
+        calls.append("json.dumps")
+        return real_dumps(*args, **kwargs)
+
+    _json.loads, _json.dumps = _trip_loads, _trip_dumps
+    try:
+        chunks = [b'{"Tables":[', b'{"TableName":"T","Rows":[[1]]}', b"]}"]
+        mod, _result, body, _response, _session = await _invoke(chunks, _payload())
+    finally:
+        _json.loads, _json.dumps = real_loads, real_dumps
+
+    assert not calls, f"200 path must not parse/serialize JSON, saw {calls}"
+    # The bytes still reached the caller, so the tripwire measured a real relay.
+    assert b"".join(body) == b"".join(chunks), "relayed bytes must match Kusto's"
+    # Belt and braces: the module no longer imports json at all, so there is no
+    # buffering path left to reintroduce by accident.
+    assert not hasattr(
+        mod, "json"
+    ), "function_app must not import json (no buffering path remains)"
+
+
 def test_streams_multiple_chunks_without_buffering():
     asyncio.run(_check_streams_multiple_chunks_without_buffering())
 
@@ -211,6 +249,10 @@ def test_execute_command_routes_to_mgmt_and_streams():
     asyncio.run(_check_execute_command_routes_to_mgmt_and_streams())
 
 
+def test_no_json_parsing_on_200_path():
+    asyncio.run(_check_no_json_parsing_on_200_path())
+
+
 if __name__ == "__main__":
     test_streams_multiple_chunks_without_buffering()
     print("  ok: streams multiple chunks without buffering")
@@ -218,4 +260,6 @@ if __name__ == "__main__":
     print("  ok: forwards clientRequestId as x-ms-client-request-id header")
     test_execute_command_routes_to_mgmt_and_streams()
     print("  ok: executeCommand routes to /v1/rest/mgmt and streams")
+    test_no_json_parsing_on_200_path()
+    print("  ok: no json.loads / json.dumps runs on the 200 path")
     print("ALL UDF STREAMING TESTS PASSED")


### PR DESCRIPTION
Follow-up to #104, closing the one part of Yadi's step-6 UDF ask that was inferred rather than asserted.

The ask was:

> UDF: 200 path yields more than one chunk for a large result, and no `json.loads` / `json.dumps` runs on that path.

#104 asserted the first half directly (3 relayed chunks, bytes verbatim). The second half was only *implied* — the test checked that `resp.text()` is never called, which proves the body is not buffered but does not prove nothing serializes.

**This adds the direct assertion.** `test_no_json_parsing_on_200_path` swaps the stdlib `json.loads` / `json.dumps` for recording wrappers around the relay, runs the 200 path, and asserts zero calls. It also asserts `function_app` no longer exposes a `json` attribute, so there is no buffering path left to reintroduce by accident.

**Verified by negative control.** Reintroducing a `json.loads` inside `relay()` makes the test fail as intended:

```
AssertionError: 200 path must not parse/serialize JSON, saw ['json.loads', 'json.loads', 'json.loads']
```

Restored, all four pass:

```
  ok: streams multiple chunks without buffering
  ok: forwards clientRequestId as x-ms-client-request-id header
  ok: executeCommand routes to /v1/rest/mgmt and streams
  ok: no json.loads / json.dumps runs on the 200 path
ALL UDF STREAMING TESTS PASSED
```

**Packaging note.** Test-only: `function_app.py` is byte-for-byte unchanged and `test_function_app.py` is not an entry in either `Deploy.zip` or `SourceCode.zip`, so no zip regeneration is needed here (unlike #104).