### PR TITLE
ci: block PRs that add zip members with owner-only permissions

### DIFF
--- a/.github/scripts/check_zip_permissions.py
+++ b/.github/scripts/check_zip_permissions.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Validate that zip archives in the repo do not ship members with
+owner-only (non-world-readable) Unix permission bits.
+
+Background: the ConnectorFunction template archives once stored 11 of 12
+members as 0600 (rw-------). When extracted on the Functions host under a
+non-root UID, those members were unreadable, causing intermittent
+permission failures. Members must either store no Unix permission bits
+(external_attr high word == 0, like a known-good build) or be
+world-readable (files 0644, dirs 0755).
+
+Usage:
+    python check_zip_permissions.py [zip ...]
+If no paths are given, every *.zip tracked in the working tree is checked.
+Exits non-zero (and prints offending members) when a bad archive is found.
+"""
+import sys
+import glob
+import zipfile
+
+# group-read (0o040) and other-read (0o004) must both be set
+REQUIRED_READ = 0o044
+
+
+def check_zip(path):
+    problems = []
+    try:
+        zf = zipfile.ZipFile(path)
+    except zipfile.BadZipFile:
+        return [f"{path}: not a valid zip archive"]
+    for info in zf.infolist():
+        mode = (info.external_attr >> 16) & 0xFFFF
+        if mode == 0:
+            # No Unix permission bits stored -> extractor applies its
+            # default umask uniformly. This matches the known-good build.
+            continue
+        perm = mode & 0o777
+        if (perm & REQUIRED_READ) != REQUIRED_READ:
+            problems.append(
+                f"{path} :: {info.filename} has mode {oct(perm)} "
+                f"(missing group/other read)"
+            )
+    return problems
+
+
+def main(argv):
+    zips = argv or sorted(glob.glob("**/*.zip", recursive=True))
+    if not zips:
+        print("No zip archives found to check.")
+        return 0
+    problems = []
+    for path in zips:
+        problems.extend(check_zip(path))
+    if problems:
+        print("Bad zip member permissions found:")
+        for p in problems:
+            print(f"  - {p}")
+        print(
+            "\nFix: repack so every member is world-readable (files 0644, "
+            "dirs 0755) or stores no Unix permission bits."
+        )
+        return 1
+    print(f"Checked {len(zips)} zip archive(s); all members OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/workflows/validate-zips.yml
+++ b/.github/workflows/validate-zips.yml
@@ -1,0 +1,22 @@
+name: Validate zip permissions
+
+on:
+  pull_request:
+    paths:
+      - '**/*.zip'
+      - '.github/scripts/check_zip_permissions.py'
+      - '.github/workflows/validate-zips.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  check-zips:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Check zip member permissions
+        run: python .github/scripts/check_zip_permissions.py


### PR DESCRIPTION
## What

Adds a CI check that runs on every pull request and **fails if any `*.zip` in the repo ships a member with owner-only (non-world-readable) Unix permission bits** — the `0600` defect that caused intermittent permission failures in the ConnectorFunction `HelloFabric` template archives.

## Why

The template `Deploy.zip` / `SourceCode.zip` previously stored 11 of 12 members as `0600` (`rw-------`). When extracted on the Functions host under a non-root UID, those members were unreadable, producing intermittent "permission" failures. That was fixed in PR #107, but nothing prevents it from regressing the next time the archives are regenerated (Python's `zipfile`, for instance, stamps `0600` by default). This adds an automated guard.

## How it works

- `.github/scripts/check_zip_permissions.py` opens every tracked `*.zip` and inspects each member's stored Unix mode. A member is OK if it stores **no Unix permission bits** (`external_attr` high word `0`, matching the known-good build) **or** is world-readable (files `0644`, dirs `0755`). A member with group/other read missing (e.g. `0600`) fails the check.
- `.github/workflows/validate-zips.yml` runs the script on `pull_request` (path-filtered to zip/script/workflow changes).

## Making it block merges

To physically prevent bad zips from merging, add the `check-zips` job as a **required status check** in this branch's protection rule (Settings → Branches). The workflow itself only reports pass/fail.

## Validation

Tested locally before opening:
- Current repo zips → **PASS** (exit 0).
- Synthesized `0600` zip → **FAIL** (exit 1) with the offending member named.

_Companion PRs add the same check to the other long-lived branches (connector-function-daily, connector-function-prod, connector-function-v1, main)._
