### PR TITLE
ci: block PRs that add bad zip members (permissions + paths)

### DIFF
--- a/.github/scripts/check_zip_permissions.py
+++ b/.github/scripts/check_zip_permissions.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Validate zip archives shipped in the repo.
+
+Two checks are enforced for every tracked *.zip:
+
+1. Permissions: no member may carry owner-only (non-world-readable) Unix
+   permission bits. Members must either store no Unix permission bits
+   (external_attr high word == 0, like a known-good build) or be
+   world-readable (files 0644, dirs 0755). This prevents the 0600 defect
+   that caused intermittent permission failures when the ConnectorFunction
+   template archives were extracted on the Functions host under a
+   non-root UID.
+
+2. Contents: no member may live under a repository-tooling path segment
+   (.github/ or .git/). Those directories hold CI and version-control
+   files that must never be packaged into a deployment/source archive.
+   Legitimate dotfiles such as .gitignore and .funcignore are filenames,
+   not path segments, and remain allowed.
+
+Usage:
+    python check_zip_permissions.py [zip ...]
+If no paths are given, every *.zip tracked in the working tree is checked.
+Exits non-zero (and prints offending members) when a bad archive is found.
+"""
+import sys
+import glob
+import zipfile
+
+# group-read (0o040) and other-read (0o004) must both be set
+REQUIRED_READ = 0o044
+
+# Path segments that must never appear inside a shipped archive.
+FORBIDDEN_SEGMENTS = {".github", ".git"}
+
+
+def check_zip(path):
+    problems = []
+    try:
+        zf = zipfile.ZipFile(path)
+    except zipfile.BadZipFile:
+        return [f"{path}: not a valid zip archive"]
+    for info in zf.infolist():
+        name = info.filename
+
+        # Content check: reject members under .github/ or .git/.
+        segments = [s for s in name.split("/") if s]
+        if any(seg in FORBIDDEN_SEGMENTS for seg in segments):
+            problems.append(
+                f"{path} :: {name} is under a forbidden path "
+                f"({', '.join(sorted(FORBIDDEN_SEGMENTS))})"
+            )
+
+        # Permission check.
+        mode = (info.external_attr >> 16) & 0xFFFF
+        if mode == 0:
+            # No Unix permission bits stored -> extractor applies its
+            # default umask uniformly. This matches the known-good build.
+            continue
+        perm = mode & 0o777
+        if (perm & REQUIRED_READ) != REQUIRED_READ:
+            problems.append(
+                f"{path} :: {name} has mode {oct(perm)} "
+                f"(missing group/other read)"
+            )
+    return problems
+
+
+def main(argv):
+    zips = argv or sorted(glob.glob("**/*.zip", recursive=True))
+    if not zips:
+        print("No zip archives found to check.")
+        return 0
+    problems = []
+    for path in zips:
+        problems.extend(check_zip(path))
+    if problems:
+        print("Bad zip members found:")
+        for p in problems:
+            print(f"  - {p}")
+        print(
+            "\nFix: repack so every member is world-readable (files 0644, "
+            "dirs 0755) or stores no Unix permission bits, and does not "
+            "include .github/ or .git/ paths."
+        )
+        return 1
+    print(f"Checked {len(zips)} zip archive(s); all members OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/workflows/validate-zips.yml
+++ b/.github/workflows/validate-zips.yml
@@ -1,0 +1,22 @@
+name: Validate zip permissions
+
+on:
+  pull_request:
+    paths:
+      - '**/*.zip'
+      - '.github/scripts/check_zip_permissions.py'
+      - '.github/workflows/validate-zips.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  check-zips:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Check zip member permissions
+        run: python .github/scripts/check_zip_permissions.py


### PR DESCRIPTION
## What

Adds a CI check that runs on every pull request and **fails if any `*.zip` in the repo ships a member that is either (a) missing group/other read (e.g. `0600`), or (b) located under a `.github/` or `.git/` path segment.** This guards against the two ways the ConnectorFunction template archives could go wrong.

## Why

- The template `Deploy.zip` / `SourceCode.zip` previously stored 11 of 12 members as `0600` (`rw-------`). Extracted on the Functions host under a non-root UID, those members were unreadable → intermittent permission failures (fixed in #107).
- Repository-tooling files (`.github/`, `.git/`) must never be packaged into a deployment/source archive.

Nothing currently prevents either from regressing when the archives are regenerated (Python's `zipfile`, for instance, stamps `0600` by default). This adds an automated guard.

## How it works

`.github/scripts/check_zip_permissions.py` opens every tracked `*.zip` and, for each member, enforces:
- **Permissions:** OK if it stores no Unix bits (`external_attr` high word `0`, matching the known-good build) or is world-readable (files `0644`, dirs `0755`). `0600` fails.
- **Path:** fails if any path segment is `.github` or `.git`. Legit dotfiles like `.gitignore` and `.funcignore` are filenames (not segments) and remain allowed.

`.github/workflows/validate-zips.yml` runs it `on: pull_request` (path-filtered to zip/script/workflow changes).

## Validation

Tested locally before opening:
- Current repo zips → **PASS**.
- `.github/` member → **FAIL**.
- `.gitignore` + `.funcignore` only → **PASS** (legit dotfiles not broken).
- `0600` member → **FAIL**.
- `.git/` member → **FAIL**.

_Companion PRs add the same check to the other long-lived branches (connector-function-prod, connector-function-v1, main)._
