### PR TITLE
ci: also reject zip members under .github/ or .git/ paths

### DIFF
--- a/.github/scripts/check_zip_permissions.py
+++ b/.github/scripts/check_zip_permissions.py
@@ -1,13 +1,21 @@
 #!/usr/bin/env python3
-"""Validate that zip archives in the repo do not ship members with
-owner-only (non-world-readable) Unix permission bits.
+"""Validate zip archives shipped in the repo.
 
-Background: the ConnectorFunction template archives once stored 11 of 12
-members as 0600 (rw-------). When extracted on the Functions host under a
-non-root UID, those members were unreadable, causing intermittent
-permission failures. Members must either store no Unix permission bits
-(external_attr high word == 0, like a known-good build) or be
-world-readable (files 0644, dirs 0755).
+Two checks are enforced for every tracked *.zip:
+
+1. Permissions: no member may carry owner-only (non-world-readable) Unix
+   permission bits. Members must either store no Unix permission bits
+   (external_attr high word == 0, like a known-good build) or be
+   world-readable (files 0644, dirs 0755). This prevents the 0600 defect
+   that caused intermittent permission failures when the ConnectorFunction
+   template archives were extracted on the Functions host under a
+   non-root UID.
+
+2. Contents: no member may live under a repository-tooling path segment
+   (.github/ or .git/). Those directories hold CI and version-control
+   files that must never be packaged into a deployment/source archive.
+   Legitimate dotfiles such as .gitignore and .funcignore are filenames,
+   not path segments, and remain allowed.
 
 Usage:
     python check_zip_permissions.py [zip ...]
@@ -21,6 +29,9 @@ import zipfile
 # group-read (0o040) and other-read (0o004) must both be set
 REQUIRED_READ = 0o044
 
+# Path segments that must never appear inside a shipped archive.
+FORBIDDEN_SEGMENTS = {".github", ".git"}
+
 
 def check_zip(path):
     problems = []
@@ -29,6 +40,17 @@ def check_zip(path):
     except zipfile.BadZipFile:
         return [f"{path}: not a valid zip archive"]
     for info in zf.infolist():
+        name = info.filename
+
+        # Content check: reject members under .github/ or .git/.
+        segments = [s for s in name.split("/") if s]
+        if any(seg in FORBIDDEN_SEGMENTS for seg in segments):
+            problems.append(
+                f"{path} :: {name} is under a forbidden path "
+                f"({', '.join(sorted(FORBIDDEN_SEGMENTS))})"
+            )
+
+        # Permission check.
         mode = (info.external_attr >> 16) & 0xFFFF
         if mode == 0:
             # No Unix permission bits stored -> extractor applies its
@@ -37,7 +59,7 @@ def check_zip(path):
         perm = mode & 0o777
         if (perm & REQUIRED_READ) != REQUIRED_READ:
             problems.append(
-                f"{path} :: {info.filename} has mode {oct(perm)} "
+                f"{path} :: {name} has mode {oct(perm)} "
                 f"(missing group/other read)"
             )
     return problems
@@ -52,12 +74,13 @@ def main(argv):
     for path in zips:
         problems.extend(check_zip(path))
     if problems:
-        print("Bad zip member permissions found:")
+        print("Bad zip members found:")
         for p in problems:
             print(f"  - {p}")
         print(
             "\nFix: repack so every member is world-readable (files 0644, "
-            "dirs 0755) or stores no Unix permission bits."
+            "dirs 0755) or stores no Unix permission bits, and does not "
+            "include .github/ or .git/ paths."
         )
         return 1
     print(f"Checked {len(zips)} zip archive(s); all members OK.")


### PR DESCRIPTION
## What

Extends the zip-permission check merged in #110 so it **also fails if any `*.zip` member lives under a `.github/` or `.git/` path segment** — preventing repository-tooling files from ever being packaged into a deployment/source archive.

## Why

#110 added the check that blocks owner-only (`0600`) zip members. This adds a second safeguard: repository-tooling directories (`.github/`, `.git/`) should never end up inside `Deploy.zip` / `SourceCode.zip`. Today they're excluded only because the packer zips the template folder and `.funcignore` lists `.git*`; this makes it an enforced invariant.

## Change

`.github/scripts/check_zip_permissions.py` now, per member, enforces both:
- **Permissions:** OK if it stores no Unix bits or is world-readable (files `0644`, dirs `0755`); `0600` fails.
- **Path:** fails if any path segment is `.github` or `.git`. Legit dotfiles like `.gitignore` and `.funcignore` are filenames (not segments) and remain allowed.

## Validation

Tested locally: current repo zips PASS; a `.github/` member FAILS; `.gitignore`+`.funcignore` PASS; a `0600` member FAILS; a `.git/` member FAILS.
